### PR TITLE
Fixed: AttributeError: 'str' object has no attribute 'exists' for hls streams

### DIFF
--- a/XstreamDL_CLI/extractors/hls/stream.py
+++ b/XstreamDL_CLI/extractors/hls/stream.py
@@ -48,7 +48,7 @@ class HLSStream(Stream):
     def set_map_flag(self):
         self.has_map_segment = True
         self.name += f'_{self.index}'
-        self.save_dir = (Path(self.save_dir).parent / self.name).resolve().as_posix()
+        self.save_dir = (Path(self.save_dir).parent / self.name).resolve()
         for segment in self.segments:
             segment.set_folder(self.save_dir)
 


### PR DESCRIPTION
To reproduce:
```
python -m -m XstreamDL_CLI.cli "https://api-kkbox-manifest.qp.kkbox.com.tw/v3/DYkFepi_nttco2PGZKWSbaIO4XcqEE2lNr61EdFc07M3o0VJlEvzH6M=/audio.m3u8?mtime=3&ver=21030010&os=webclient&osver=4.15.0-101-generic&dist=0050&dist2=0000&sid=G14uspHkCb4000000000000001WS8Dl00000000000K335PoQDS001WNrCqff31&play_mode=webclient&cdn=cloudfront&__gda__=1616868751_7b623b7985ee850cb16b4f04b9ee3829&mtime=3&ver=21030010&os=webclient&osver=4.15.0-101-generic&dist=0050&dist2=0000&sid=G14uspHkCb4000000000000001WS8Dl00000000000K335PoQDS001WNrCqff31&play_mode=webclient&cdn=cloudfront&__gda__=1616868751_7b623b7985ee850cb16b4f04b9ee3829"
```

Will raise `AttributeError: 'str' object has no attribute 'exists'` because `self.save_dir` is getting changed from type `PosixPath` to type `str` when `as_posix()` is called on it.
