### PR TITLE
fix: failed to concat if there are too many segments

### DIFF
--- a/XstreamDL_CLI/extractor.py
+++ b/XstreamDL_CLI/extractor.py
@@ -77,6 +77,7 @@ class Extractor:
         elif '<SmoothStreamingMedia' in content and '</SmoothStreamingMedia>' in content:
             return self.parse_as_mss(uri_type, uri, content, parent_stream)
         else:
+            print('无法获取视频流信息')
             return []
 
     def parse_as_hls(self, uri_type: str, uri: str, content: str, parent_stream: HLSStream = None) -> List[HLSStream]:

--- a/XstreamDL_CLI/util/concat.py
+++ b/XstreamDL_CLI/util/concat.py
@@ -57,7 +57,7 @@ class Concat:
                 return cmds, _tmp_outs
             else:
                 for _names, _out in new_names:
-                    cmds.append(f'cat {" ".join(_names)} "{_out}"')
+                    cmds.append(f'cat {" ".join(_names)} > "{_out}"')
                 return cmds, _tmp_outs
         if platform.system() == 'Windows':
             return [f'copy /b {"+".join(names)} "{out}"'], []

--- a/XstreamDL_CLI/util/concat.py
+++ b/XstreamDL_CLI/util/concat.py
@@ -46,7 +46,9 @@ class Concat:
         out = out_path.absolute().as_posix()
         cmds = [] # type: List[str]
         if args.raw_concat is False:
-            return [f'ffmpeg -i concat:"{"|".join(names)}" -c copy -y "{out}" > nul'], []
+            with open('concat.list', 'wt') as f:
+                f.writelines([f"file '{name}'\r\n" for name in names])
+            return [f'ffmpeg -f concat -i "concat.list" -c copy -y "{out}" > nul'], []
         if len(names) > ONCE_MAX_FILES:
             new_names, _tmp_outs = Concat.gen_new_names(names, out)
             if platform.system() == 'Windows':


### PR DESCRIPTION
When the number of segments is more than 1201, concat will be failed.

You can reinplement that bug with:

```bash
touch {0001..1202}.ts
ls *.ts | ffmpeg -i "concat:`paste -s -d"|" -`" -c copy test.mp4
```